### PR TITLE
Add long tail requests to benchmark.

### DIFF
--- a/cpp/benchmarks/single_node/benchmark_multi_threads_client.cc
+++ b/cpp/benchmarks/single_node/benchmark_multi_threads_client.cc
@@ -8,6 +8,9 @@
 #include <chrono>
 #include <thread>
 
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
 int main(int argc, char *argv[]) {
     int thread_num = 12;
     int call_interval_ms = 50;
@@ -17,10 +20,15 @@ int main(int argc, char *argv[]) {
         std::thread th([call_interval_ms]() {
             dousi::RpcClient rpc_client {"127.0.0.1:10002"};
             auto bm_service = rpc_client.GetService("BenchmarkService");
-            int i = 0;
+            uint32_t i = 0;
+            std::this_thread::sleep_for(std::chrono::microseconds(call_interval_ms));
             while(true) {
-                bm_service.Call(dousi::Remote(&BenchmarkService::Echo), "hello world.");
-                std::this_thread::sleep_for(std::chrono::microseconds(call_interval_ms));
+                if (unlikely(i % 100 == 0)) {
+                    bm_service.Call(dousi::Remote(&BenchmarkService::SlowlyEcho), "slowly echo.");
+                } else {
+                    bm_service.Call(dousi::Remote(&BenchmarkService::Echo), "hello world.");
+                }
+                ++i;
             }
             std::cout << "Finished th id = " << std::this_thread::get_id() << std::endl;
             int a;

--- a/cpp/benchmarks/single_node/benchmark_server.cc
+++ b/cpp/benchmarks/single_node/benchmark_server.cc
@@ -8,6 +8,7 @@ int main(int argc, char *argv[]) {
     dousi::RpcServer rpc_server {"127.0.0.1:10002"};
     auto bm_service = rpc_server.CreateService<BenchmarkService>();
     bm_service.RegisterMethod(dousi::Remote(&BenchmarkService::Echo));
+    bm_service.RegisterMethod(dousi::Remote(&BenchmarkService::SlowlyEcho));
     rpc_server.Loop();
 
     return 0;

--- a/cpp/benchmarks/single_node/benchmark_service.h
+++ b/cpp/benchmarks/single_node/benchmark_service.h
@@ -13,6 +13,12 @@ public:
         return str;
     }
 
+    std::string SlowlyEcho(const std::string &str) {
+        qps_.increase();
+        std::this_thread::sleep_for(std::chrono::milliseconds {10});
+        return str;
+    }
+
 private:
     Qps qps_;
 };


### PR DESCRIPTION
We add the long-tail requests to benchmark. It shows that 50% perf deduced after adding the 1% long tail requests which sleep 10 ms.